### PR TITLE
var visual uses Dart Map vs String for clarity

### DIFF
--- a/examples/ShrineApp/lib/model/app_state_model.dart
+++ b/examples/ShrineApp/lib/model/app_state_model.dart
@@ -161,10 +161,13 @@ class AppStateModel extends Model {
   }
 
   void setVisuals() {
-    var visual =
-        "{\"screen\":\"$_currentScreen\", \"order\":${cartToJson()}, \"total\":${totalCost}}";
+    var visual = {
+      "screen": _currentScreen, 
+      "order": cartToJson(), 
+      "total": totalCost
+    };
     print(visual);
-    AlanVoice.setVisualState(visual);
+    AlanVoice.setVisualState(json.encode(visual));
   }
 
   void highlightValue(String value) {


### PR DESCRIPTION
Use native Dart Map with conversion to json for 'visual' variable instead of string interpolation and escaped double quotes. Makes the data more clear. 